### PR TITLE
Update Dockerfile to have the right port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ USER git
 ENTRYPOINT ["/usr/sbin/init"]
 CMD ["/init", "/usr/sbin/sshd", "-D"]
 
-EXPOSE 22
+EXPOSE 2222


### PR DESCRIPTION
sshd is actually running on tcp/2222, not 22.